### PR TITLE
Защита от CSRF

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -104,6 +104,7 @@ func main() {
 	app := &internal.App{
 		Logger:        logger,
 		Repositories:  repositories,
+		CSRFSecret:    conf.Server.CSRFSecret,
 		Usecases:      usecases,
 		Microservices: microservices,
 	}

--- a/configs/example-conf.yml
+++ b/configs/example-conf.yml
@@ -4,6 +4,8 @@ server:
   port: 8090
   frontURI: "http://192.168.77.130:8000"
   mediadir: "media/UnCompressed/"
+  csrf_secret: "rand string"
+
   
 
 database:

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -25,6 +25,7 @@ type ServerConfig struct {
 	Port     int    `yaml:"port"`
 	Front    string `yaml:"frontURI"`
 	MediaDir string `yaml:"mediadir"`
+	CSRFSecret string `yaml:"csrf_secret"`
 }
 
 type DataBaseConfig struct {

--- a/internal/layers.go
+++ b/internal/layers.go
@@ -15,18 +15,19 @@ import (
 type App struct {
 	Logger         *logrus.Logger
 	BackendAddress string
+	CSRFSecret     string
 	Repositories   *Repositories
 	Usecases       *Usecases
 	Microservices  *Microservices
 }
 
 type Repositories struct {
-	EmployerRepository         employer.IEmployerRepository
-	ApplicantRepository        applicant.IApplicantRepository
-	PortfolioRepository        portfolio.IPortfolioRepository
-	CVRepository               cvs.ICVsRepository
-	VacanciesRepository        vacancies.IVacanciesRepository
-	FileLoadingRepository      fileloading.IFileLoadingRepository
+	EmployerRepository    employer.IEmployerRepository
+	ApplicantRepository   applicant.IApplicantRepository
+	PortfolioRepository   portfolio.IPortfolioRepository
+	CVRepository          cvs.ICVsRepository
+	VacanciesRepository   vacancies.IVacanciesRepository
+	FileLoadingRepository fileloading.IFileLoadingRepository
 }
 
 type Usecases struct {

--- a/internal/middleware/csrf_protection.go
+++ b/internal/middleware/csrf_protection.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"fmt"
 	"net/http"
+	"errors"
 
 	"github.com/go-park-mail-ru/2024_2_VKatuny/internal"
 	"github.com/go-park-mail-ru/2024_2_VKatuny/internal/pkg/commonerrors"
@@ -80,7 +81,7 @@ func CSRFProtection(next dto.HandlerFunc, app *internal.App) dto.HandlerFunc {
 		)
 		if err != nil {
 			errMsg := commonerrors.ErrUncoveredError
-			if err == utils.ErrTokenExpired {
+			if errors.Is(err, utils.ErrTokenExpired) {
 				errMsg = commonerrors.ErrFrontCSRFExpired
 			}
 			logger.Errorf("%s: got err %s", fn, err)

--- a/internal/middleware/csrf_protection.go
+++ b/internal/middleware/csrf_protection.go
@@ -1,0 +1,83 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-park-mail-ru/2024_2_VKatuny/internal"
+	"github.com/go-park-mail-ru/2024_2_VKatuny/internal/pkg/commonerrors"
+	"github.com/go-park-mail-ru/2024_2_VKatuny/internal/pkg/dto"
+	"github.com/go-park-mail-ru/2024_2_VKatuny/internal/utils"
+	"github.com/sirupsen/logrus"
+)
+
+type HandlerFunc func(w http.ResponseWriter, r *http.Request)
+
+func CSRFProtection(next HandlerFunc, app *internal.App) HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		fn := "middleware.CSRFProtection"
+		logger, ok := r.Context().Value(dto.LoggerContextKey).(*logrus.Logger)
+		if !ok {
+			fmt.Printf("WARNING: Can't get logger from context. Processing without it")
+		}
+		logger.Debugf("%s: got logger from context", fn)
+
+		user, ok := r.Context().Value(dto.UserContextKey).(*dto.UserFromSession)
+		if !ok {
+			logger.Errorf("%s: got err %s", fn, "failed to get user from context")
+			UniversalMarshal(w, http.StatusInternalServerError, dto.JSONResponse{
+				HTTPStatus: http.StatusInternalServerError,
+				Error:      "failed to get user from context",
+			})
+			return
+		}
+		logger.Debugf("%s: got user from context: %v", fn, user)
+
+		session, err := r.Cookie(dto.SessionIDName)
+		if err == http.ErrNoCookie || session.Value == "" {
+			logger.Errorf("checking session: got err %s", err)
+			UniversalMarshal(w, http.StatusForbidden, dto.JSONResponse{
+				HTTPStatus: http.StatusForbidden,
+				Error:      err.Error(),
+			})
+			return
+		}
+
+		token := r.Header.Get("X-CSRF-Token")
+		if token == "" {
+			logger.Errorf("%s: csrf token is empty", fn)
+			UniversalMarshal(w, http.StatusForbidden, dto.JSONResponse{
+				HTTPStatus: http.StatusForbidden,
+				Error:      "csrf token is empty",
+			})
+			return
+		}
+		logger.Debugf("%s: got token: %s", fn, token)
+
+		cryptToken := utils.NewCryptToken(app.CSRFSecret)
+		ok, err = cryptToken.Check(user.ID, user.UserType, session.Value, token)
+		if err != nil {
+			errMsg := commonerrors.ErrUncoveredError
+			if err == utils.ErrTokenExpired {
+				errMsg = commonerrors.ErrFrontCSRFExpired
+			}
+			logger.Errorf("%s: got err %s", fn, err)
+			UniversalMarshal(w, http.StatusForbidden, dto.JSONResponse{
+				HTTPStatus: http.StatusForbidden,
+				Error:      errMsg.Error(),
+			})
+			return
+		}
+
+		if !ok {
+			logger.Errorf("%s: token doesn't match", fn)
+			UniversalMarshal(w, http.StatusForbidden, dto.JSONResponse{
+				HTTPStatus: http.StatusForbidden,
+				Error:      commonerrors.ErrFrontCSRFTokenDoesntMatch.Error(),
+			})
+			return
+		}
+
+		next(w, r)
+	}
+}

--- a/internal/mux/mux_init.go
+++ b/internal/mux/mux_init.go
@@ -33,6 +33,7 @@ func Init(app *internal.App) *mux.Router {
 	router.HandleFunc("/api/v1/applicant/{id:[0-9]+}/profile", applicantHandlers.GetProfile).
 		Methods(http.MethodGet)
 	updateApplicantProfile := middleware.RequireAuthorization(applicantHandlers.UpdateProfile, app, dto.UserTypeApplicant)
+	updateApplicantProfile = middleware.CSRFProtection(updateApplicantProfile, app)
 	router.HandleFunc("/api/v1/applicant/{id:[0-9]+}/profile", updateApplicantProfile).
 		Methods(http.MethodPut)
 	router.HandleFunc("/api/v1/applicant/{id:[0-9]+}/portfolio", applicantHandlers.GetPortfolios).
@@ -46,6 +47,7 @@ func Init(app *internal.App) *mux.Router {
 	router.HandleFunc("/api/v1/employer/{id:[0-9]+}/profile", employerHandlers.GetProfile).
 		Methods(http.MethodGet)
 	updateEmployerProfile := middleware.RequireAuthorization(employerHandlers.UpdateProfile, app, dto.UserTypeEmployer)
+	updateEmployerProfile = middleware.CSRFProtection(updateEmployerProfile, app)
 	router.HandleFunc("/api/v1/employer/{id:[0-9]+}/profile", updateEmployerProfile).
 		Methods(http.MethodPut)
 	router.HandleFunc("/api/v1/employer/{id:[0-9]+}/vacancies", employerHandlers.GetEmployerVacancies).
@@ -53,14 +55,17 @@ func Init(app *internal.App) *mux.Router {
 
 	cvsHandlers := cv_delivery.NewCVsHandler(app)
 	createCV := middleware.RequireAuthorization(cvsHandlers.CreateCV, app, dto.UserTypeApplicant)
+	createCV = middleware.CSRFProtection(createCV, app)
 	router.HandleFunc("/api/v1/cv", createCV).
 		Methods(http.MethodPost)
 	router.HandleFunc("/api/v1/cv/{id:[0-9]+}", cvsHandlers.GetCV).
 		Methods(http.MethodGet)
 	updateCV := middleware.RequireAuthorization(cvsHandlers.UpdateCV, app, dto.UserTypeApplicant)
+	updateCV = middleware.CSRFProtection(updateCV, app)
 	router.HandleFunc("/api/v1/cv/{id:[0-9]+}", updateCV).
 		Methods(http.MethodPut)
 	deleteCV := middleware.RequireAuthorization(cvsHandlers.DeleteCV, app, dto.UserTypeApplicant)
+	deleteCV = middleware.CSRFProtection(deleteCV, app)
 	router.HandleFunc("/api/v1/cv/{id:[0-9]+}", deleteCV).
 		Methods(http.MethodDelete)
 	router.HandleFunc("/api/v1/cvs", cvsHandlers.SearchCVs).
@@ -70,27 +75,34 @@ func Init(app *internal.App) *mux.Router {
 	router.HandleFunc("/api/v1/vacancies", vacanciesHandlers.GetVacancies).
 		Methods(http.MethodGet)
 	createVacancy := middleware.RequireAuthorization(vacanciesHandlers.CreateVacancy, app, dto.UserTypeEmployer)
+	createVacancy = middleware.CSRFProtection(createVacancy, app)
 	router.HandleFunc("/api/v1/vacancy", createVacancy).
 		Methods(http.MethodPost)
 	router.HandleFunc("/api/v1/vacancy/{id:[0-9]+}", vacanciesHandlers.GetVacancy).
 		Methods(http.MethodGet)
 	updateVacancy := middleware.RequireAuthorization(vacanciesHandlers.UpdateVacancy, app, dto.UserTypeEmployer)
+	updateVacancy = middleware.CSRFProtection(updateVacancy, app)
 	router.HandleFunc("/api/v1/vacancy/{id:[0-9]+}", updateVacancy).
 		Methods(http.MethodPut)
 	deleteVacancy := middleware.RequireAuthorization(vacanciesHandlers.DeleteVacancy, app, dto.UserTypeEmployer)
+	deleteVacancy = middleware.CSRFProtection(deleteVacancy, app)
 	router.HandleFunc("/api/v1/vacancy/{id:[0-9]+}", deleteVacancy).
 		Methods(http.MethodDelete)
 
 	subscribe := middleware.RequireAuthorization(vacanciesHandlers.SubscribeVacancy, app, dto.UserTypeApplicant)
+	subscribe = middleware.CSRFProtection(subscribe, app)
 	router.HandleFunc("/api/v1/vacancy/{id:[0-9]+}/subscription", subscribe).
 		Methods(http.MethodPost)
 	unsubscribe := middleware.RequireAuthorization(vacanciesHandlers.UnsubscribeVacancy, app, dto.UserTypeApplicant)
+	unsubscribe = middleware.CSRFProtection(unsubscribe, app)
 	router.HandleFunc("/api/v1/vacancy/{id:[0-9]+}/subscription", unsubscribe).
 		Methods(http.MethodDelete)
 	subscription := middleware.RequireAuthorization(vacanciesHandlers.GetVacancySubscription, app, dto.UserTypeApplicant)
+	subscription = middleware.CSRFProtection(subscription, app)
 	router.HandleFunc("/api/v1/vacancy/{id:[0-9]+}/subscription", subscription).
 		Methods(http.MethodGet)
 	subscribers := middleware.RequireAuthorization(vacanciesHandlers.GetVacancySubscribers, app, dto.UserTypeEmployer)
+	subscribers = middleware.CSRFProtection(subscribers, app)
 	router.HandleFunc("/api/v1/vacancy/{id:[0-9]+}/subscribers", subscribers).
 		Methods(http.MethodGet)
 

--- a/internal/pkg/commonerrors/common.go
+++ b/internal/pkg/commonerrors/common.go
@@ -21,8 +21,11 @@ var (
 
 // Errors to front
 var (
-	ErrFrontBadSlug          = fmt.Errorf("bad slug")
-	ErrFrontUnableToCastSlug = fmt.Errorf("unable to cast slug")
-	ErrFrontMethodNotAllowed = fmt.Errorf("method not allowed")
-	ErrFrontServiceNotFound  = fmt.Errorf("service not found")
+	ErrFrontBadSlug              = fmt.Errorf("bad slug")
+	ErrFrontUnableToCastSlug     = fmt.Errorf("unable to cast slug")
+	ErrFrontMethodNotAllowed     = fmt.Errorf("method not allowed")
+	ErrFrontServiceNotFound      = fmt.Errorf("service not found")
+	ErrFrontCSRFExpired          = fmt.Errorf("csrf token expired")
+	ErrFrontCSRFTokenDoesntMatch = fmt.Errorf("csrf token doesn't match")
+	ErrUncoveredError            = fmt.Errorf("uncovered error")
 )

--- a/internal/pkg/session/delivery/session_handlers.go
+++ b/internal/pkg/session/delivery/session_handlers.go
@@ -20,6 +20,7 @@ import (
 type SessionHandlers struct {
 	logger         *logrus.Entry
 	backendURL     string
+	secretCSRF     string
 	authClientGRPC auth_grpc.AuthorizationClient
 }
 
@@ -31,6 +32,7 @@ func NewSessionHandlers(app *internal.App) *SessionHandlers {
 	return &SessionHandlers{
 		logger:         &logrus.Entry{Logger: app.Logger},
 		backendURL:     app.BackendAddress,
+		secretCSRF:     app.CSRFSecret,
 		authClientGRPC: app.Microservices.Auth,
 	}
 }
@@ -103,6 +105,20 @@ func (h *SessionHandlers) IsAuthorized(w http.ResponseWriter, r *http.Request) {
 		UserType: userData.UserType,
 	}
 	h.logger.Debugf("%s: user: %v", fn, user)
+
+	cryptToken := utils.NewCryptToken(h.secretCSRF)
+	tokenCSRF, err := cryptToken.Create(user.ID, user.UserType, session.Value) 
+	if err != nil {
+		h.logger.Errorf("%s: got err %s", fn, err)
+		middleware.UniversalMarshal(w, http.StatusInternalServerError, dto.JSONResponse{
+			HTTPStatus: http.StatusInternalServerError,
+			Error:      err.Error(),
+		})
+		return
+	}
+	h.logger.Debugf("%s: CSRF token created: %s", fn, tokenCSRF)
+	w.Header().Set("X-CSRF-Token", tokenCSRF)
+
 	middleware.UniversalMarshal(w, http.StatusOK, dto.JSONResponse{
 		HTTPStatus: http.StatusOK,
 		Body:       user,

--- a/internal/utils/csrf_token.go
+++ b/internal/utils/csrf_token.go
@@ -1,0 +1,111 @@
+package utils
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+const TokenExpirationTime = 30 * time.Minute
+
+var (
+	ErrShortCipher      = fmt.Errorf("short cipher")
+	ErrDecryptionFailed = fmt.Errorf("decryption failed")
+	ErrTokenExpired     = fmt.Errorf("csrf token expired")
+)
+
+type CryptToken struct {
+	secret []byte
+}
+
+type CSRFTokenData struct {
+	SessionID string
+	UserID    uint64
+	UserType  string
+	TTL       int64
+}
+
+func NewCryptToken(secret string) *CryptToken {
+	key := []byte(secret)
+	return &CryptToken{secret: key}
+}
+
+func (c *CryptToken) Create(userID uint64, UserType, SessionID string) (string, error) {
+	block, err := aes.NewCipher(c.secret)
+	if err != nil {
+		return "", err
+	}
+
+	AESGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, AESGCM.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+
+	Token := &CSRFTokenData{
+		SessionID: SessionID,
+		UserID:    userID,
+		UserType:  UserType,
+		TTL:       time.Now().Add(TokenExpirationTime).Unix(),
+	}
+	TokenJSON, err := json.Marshal(Token)
+	if err != nil {
+		return "", err
+	}
+	cipherText := AESGCM.Seal(nil, nonce, TokenJSON, nil)
+
+	result := make([]byte, 0)
+	result = append(result, nonce...)
+	result = append(result, cipherText...)
+
+	return base64.StdEncoding.EncodeToString(result), nil
+}
+
+func (c *CryptToken) Check(userID uint64, UserType, SessionID, inputToken string) (bool, error) {
+	token, err := base64.StdEncoding.DecodeString(inputToken)
+	if err != nil {
+		return false, err
+	}
+
+	block, err := aes.NewCipher(c.secret)
+	if err != nil {
+		return false, err
+	}
+	AESGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return false, err
+	}
+
+	nonceSize := AESGCM.NonceSize()
+	if len(token) < nonceSize {
+		return false, ErrShortCipher
+	}
+
+	nonce, cipherText := token[:nonceSize], token[nonceSize:]
+	decodedText, err := AESGCM.Open(nil, nonce, cipherText, nil)
+	if err != nil {
+		return false, ErrDecryptionFailed
+	}
+
+	tokenData := new(CSRFTokenData)
+	err = json.Unmarshal(decodedText, tokenData)
+	if err != nil {
+		return false, err
+	}
+
+	if tokenData.TTL < time.Now().Unix() {
+		return false, ErrTokenExpired
+	}
+
+	return tokenData.UserID == userID &&
+		tokenData.SessionID == SessionID &&
+		tokenData.UserType == UserType, nil
+}


### PR DESCRIPTION
Выбран stateless подход, который шифрует ID сессии, ID пользователя и его тип и отправляет его с заголовком запроса на фронт.
На запрос к `/api/v1/authorized` вместе с кукой также отдаётся `X-CSRF-Token` с TTL в 30 мин.
На ручки, требующие защиты навешивается миддлвара, которая расшифровывает и сравнивает этот токен с данными сессии